### PR TITLE
Fix loader checks not hitting win32 paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,9 +65,14 @@ module.exports = config => ({
             ),
 
             use: rule.use.map(loader => {
+              // Regexes for matching loader paths in Windows and Unix
+              // Unix: /css-loader/, Windows: \css-loader\
+              const cssTest = /[\\/]css-loader[\\/]/
+              const sassTest = /[\\/]sass-loader[\\/]/
+
               if (
                 testString === '/\\.module\\.(scss|sass)$/' && // CSS Modules
-                loader.loader.includes('/css-loader/')
+                cssTest.test(loader.loader)
               ) {
                 return {
                   ...loader,
@@ -98,7 +103,7 @@ module.exports = config => ({
                     }
                   }
                 }
-              } else if (loader.loader.includes('/sass-loader/')) {
+              } else if (sassTest.test(loader.loader)) {
                 /* Replace sass-loader with stylus-loader. */
                 return 'stylus-loader'
               }

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = config => ({
                           .slice(0, 5)
 
                         const resourceIdent = (
-                          relativePath.endsWith('/index.module.styl')
+                          /[\\/]index.module.styl$/.test(relativePath)
                             ? basename(dirname(relativePath))
                             : basename(relativePath).slice(0, -12)
                         ).replace(NOT_LETTER_OR_NUMBER, '_')


### PR DESCRIPTION
The tests assumed that file paths had forward slashes, which made them not trigger on MS Windows. These new regexes hit on both unix and windows style paths.